### PR TITLE
Fix #4

### DIFF
--- a/goldfinder/checks.py
+++ b/goldfinder/checks.py
@@ -40,6 +40,10 @@ def roary_check(roary_file):
     except FileNotFoundError:
         exit('Could not find specified file. Perhaps a typo or you gave a panX folder without '
              'specifying -f panx?')
+    except pd.errors.ParserError as e:
+        print("\nEncountered a parser error. Did you specify the correct input format using -f?")
+        print("If so, your file might contain unquoted commas. This was the pandas error:")
+        exit(e)
 
     if list(df.columns.values)[0:13] != ['Non-unique Gene name', 'Annotation', 'No. isolates',
                                          'No. sequences', 'Avg sequences per isolate',


### PR DESCRIPTION
 The problem is caused by un-escaped commas in .csv files. If the input contains such commas, we cannot do anything about it, but now the user gets an informative error message. To avoid producing such illegal .csv files, output.py was altered to check every field in the output .csv for commas, and escape it with quotes if necessary.

--tests option returns fine